### PR TITLE
Fixed Dell Thermal Management not showing current mode

### DIFF
--- a/gr.ictpro.jsalatas.plasma.pstate/contents/code/set_prefs.sh
+++ b/gr.ictpro.jsalatas.plasma.pstate/contents/code/set_prefs.sh
@@ -175,7 +175,7 @@ if [ -z "$energy_perf" ]; then
     awk '{ printf "%s\n", $2; }' | head -n 1`
 fi
 if check_dell_thermal; then
-    thermal_mode=`smbios-thermal-ctl -g | grep -C 1 "Current Thermal Modes:"  | tail -n 1 | awk '{$1=$1;print}' | sed "s/\t//g" | sed "s/ /-/g" | tr [A-Z] [a-z] `
+    thermal_mode=`smbios-thermal-ctl -g | grep -C 1 "Current Thermal Modes:"  | tail -n 1 | awk '{$1=$1;print}' | sed "s/\t//g" | sed "s/ /-/g" | tr "[A-Z]" "[a-z]" `
 fi
 if check_lg_drivers; then
     lg_battery_charge_limit=`cat $LG_BATTERY_CHARGE_LIMIT`


### PR DESCRIPTION
On Dell systems, the current Thermal Management mode was not being
shown. (None of the profiles were highlighted.) The arguments for the `tr` command were incorrect. This is now fixed by adding quotes.

(Sorry for not creating an issue, I was bored.)